### PR TITLE
Fix empty arrays parsing

### DIFF
--- a/src/php_pq_misc.c
+++ b/src/php_pq_misc.c
@@ -318,6 +318,9 @@ static ZEND_RESULT_CODE parse_element(ArrayParserState *a, char delim)
 	case '{':
 		return parse_array(a);
 
+	case '}':
+		return SUCCESS;
+
 	case '"':
 		a->quotes = 1;
 		++a->ptr;

--- a/tests/types002.phpt
+++ b/tests/types002.phpt
@@ -25,14 +25,15 @@ true as bool,
 '2013-01-01 01:01:01'::timestamp as timestamp,
 '2013-01-01 01:01:01 UTC'::timestamptz as timestamptz,
 array[array[1,2,3],array[4,5,6],array[NULL::int,NULL::int,NULL::int]] as intarray,
-array[box(point(1,2),point(2,3)),box(point(4,5),point(5,6))] as boxarray
+array[box(point(1,2),point(2,3)),box(point(4,5),point(5,6))] as boxarray,
+array[]::text[] as emptyarray
 ");
 var_dump($r->fetchRow(pq\Result::FETCH_ASSOC));
 ?>
 DONE
 --EXPECTF--
 Test
-array(12) {
+array(13) {
   ["null"]=>
   NULL
   ["bool"]=>
@@ -116,6 +117,9 @@ array(12) {
     string(11) "(2,3),(1,2)"
     [1]=>
     string(11) "(5,6),(4,5)"
+  }
+  ["emptyarray"]=>
+  array(0) {
   }
 }
 DONE


### PR DESCRIPTION
There is a bug in array parsing logic.

PostgreSQL allows me to store empty array in `text[]` columns (like `{}`) but then I use ext-pq to retrieve the data I get `[""]` (an array with an empty string). From the point of database values `{}` and `{""}` are not the same but ext-pq will return same parsing result for both of them.

Also, if I use column of `integer[]` type with value `{}` (empty array) I still got `[""]` from ext-pq.

The PR fixes such behavior.