### PR TITLE
Fix build with 7.4 on macOS

### DIFF
--- a/src/php_pqconn.h
+++ b/src/php_pqconn.h
@@ -46,7 +46,7 @@ typedef struct php_pqconn_object {
 
 typedef struct php_pqconn_resource_factory_data {
 	char *dsn;
-	ulong flags;
+	uint32_t flags;
 } php_pqconn_resource_factory_data_t;
 
 extern php_resource_factory_ops_t *php_pqconn_get_resource_factory_ops(void);


### PR DESCRIPTION
Complier complained `ulong` was undefined, so replaced with `uint32_t`.