### PR TITLE
fix library version in PHPinfo

### DIFF
--- a/src/php_pq_module.c
+++ b/src/php_pq_module.c
@@ -105,7 +105,11 @@ static PHP_MINFO_FUNCTION(pq)
 	php_info_print_table_header(3, "Used Library", "Compiled", "Linked");
 #ifdef HAVE_PQLIBVERSION
 	libpq_v = PQlibVersion();
-	slprintf(libpq_version, sizeof(libpq_version), "%d.%d.%d", libpq_v/10000%100, libpq_v/100%100, libpq_v%100);
+	if (libpq_v < 100000) {
+		slprintf(libpq_version, sizeof(libpq_version), "%d.%d.%d", libpq_v/10000, libpq_v/100%100, libpq_v%100);
+	} else {
+		slprintf(libpq_version, sizeof(libpq_version), "%d.%d", libpq_v/10000, libpq_v%100);
+	}
 #endif
 	php_info_print_table_row(3, "libpq", PHP_PQ_LIBVERSION, libpq_version);
 	php_info_print_table_end();


### PR DESCRIPTION
Without this
```
Used Library => Compiled => Linked
libpq => 14.3 => 14.0.3
```

With 
```
Used Library => Compiled => Linked
libpq => 14.3 => 14.3
```

From documentation https://www.postgresql.org/docs/15/libpq-status.html

> Applications might use this function to determine the version of the database server they are connected to. The result is formed by multiplying the server's major version number by 10000 and adding the minor version number. For example, version 10.1 will be returned as 100001, and version 11.0 will be returned as 110000. Zero is returned if the connection is bad.
> 
> Prior to major version 10, PostgreSQL used three-part version numbers in which the first two parts together represented the major version. For those versions, [PQserverVersion](https://www.postgresql.org/docs/15/libpq-status.html#LIBPQ-PQSERVERVERSION) uses two digits for each part; for example version 9.1.5 will be returned as 90105, and version 9.2.0 will be returned as 90200.