### PR TITLE
version properties

### DIFF
--- a/config9.m4
+++ b/config9.m4
@@ -99,6 +99,8 @@ if test "$PHP_PQ" != "no"; then
 	PHP_SUBST(PQ_SHARED_LIBADD)
 
 	PQ_CHECK_FUNC(PQlibVersion)
+	PQ_CHECK_FUNC(PQprotocolVersion)
+	PQ_CHECK_FUNC(PQserverVersion)
 	PQ_CHECK_FUNC(PQconninfo)
 	PQ_CHECK_FUNC(PQsetSingleRowMode)
 

--- a/package.xml
+++ b/package.xml
@@ -118,6 +118,7 @@
     <file role="test" name="async010.phpt" />
     <file role="test" name="basic001.phpt" />
     <file role="test" name="basic002.phpt" />
+    <file role="test" name="basic003.phpt" />
     <file role="test" name="bound002.phpt" />
     <file role="test" name="callback001.phpt" />
     <file role="test" name="callback002.phpt" />

--- a/src/php_pq_misc.c
+++ b/src/php_pq_misc.c
@@ -29,6 +29,14 @@
 #undef PHP_PQ_TYPE
 #include "php_pq_type.h"
 
+/* convert version to string */
+extern void php_pq_version_to_string(int version, char *buffer, int len) {
+	if (version < 100000) {
+		slprintf(buffer, len, "%d.%d.%d", version/10000, version/100%100, version%100);
+	} else { /* since version 10 */
+		slprintf(buffer, len, "%d.%d", version/10000, version%100);
+	}
+}
 
 /* clear result object associated with a result handle */
 void php_pqres_clear(PGresult *r) {

--- a/src/php_pq_misc.h
+++ b/src/php_pq_misc.h
@@ -101,6 +101,9 @@ extern int php_pq_compare_index(const void *lptr, const void *rptr);
 		 ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, required_num_args)
 #endif
 
+#ifndef ZEND_ACC_READONLY
+#define ZEND_ACC_READONLY 0
+#endif
 
 extern PHP_MINIT_FUNCTION(pq_misc);
 

--- a/src/php_pq_misc.h
+++ b/src/php_pq_misc.h
@@ -33,6 +33,8 @@ extern PGresult *php_pq_exec_params(PGconn *conn, const char *command, int nPara
 extern PGresult *php_pq_prepare(PGconn *conn, const char *stmtName, const char *query, int nParams, const Oid *paramTypes);
 extern PGresult *php_pq_exec_prepared(PGconn *conn, const char *stmtName, int nParams, const char *const * paramValues, const int *paramLengths, const int *paramFormats, int resultFormat);
 
+/* convert version to string */
+extern void php_pq_version_to_string(int version, char *buffer, int len);
 
 /* trim LF from EOL */
 extern char *php_pq_rtrim(char *e);

--- a/src/php_pq_module.c
+++ b/src/php_pq_module.c
@@ -105,11 +105,7 @@ static PHP_MINFO_FUNCTION(pq)
 	php_info_print_table_header(3, "Used Library", "Compiled", "Linked");
 #ifdef HAVE_PQLIBVERSION
 	libpq_v = PQlibVersion();
-	if (libpq_v < 100000) {
-		slprintf(libpq_version, sizeof(libpq_version), "%d.%d.%d", libpq_v/10000, libpq_v/100%100, libpq_v%100);
-	} else {
-		slprintf(libpq_version, sizeof(libpq_version), "%d.%d", libpq_v/10000, libpq_v%100);
-	}
+	php_pq_version_to_string(libpq_v, libpq_version, sizeof(libpq_version));
 #endif
 	php_info_print_table_row(3, "libpq", PHP_PQ_LIBVERSION, libpq_version);
 	php_info_print_table_end();

--- a/src/php_pq_module.c
+++ b/src/php_pq_module.c
@@ -105,7 +105,11 @@ static PHP_MINFO_FUNCTION(pq)
 	php_info_print_table_header(3, "Used Library", "Compiled", "Linked");
 #ifdef HAVE_PQLIBVERSION
 	libpq_v = PQlibVersion();
-	slprintf(libpq_version, sizeof(libpq_version), "%d.%d.%d", libpq_v/10000%100, libpq_v/100%100, libpq_v%100);
+	if (libpq_v < 100000) {
+		slprintf(libpq_version, sizeof(libpq_version), "%d.%d.%d", libpq_v/10000, libpq_v/100%100, libpq_v%100);
+	} else {
+		slprintf(libpq_version, sizeof(libpq_version), "%d.%d", libpq_v/10000, libpq_v%100);
+	}
 #endif
 	php_info_print_table_row(3, "libpq", PHP_PQ_LIBVERSION, libpq_version);
 	php_info_print_table_end();

--- a/src/php_pqconn.c
+++ b/src/php_pqconn.c
@@ -505,12 +505,15 @@ static void php_pqconn_object_read_lib_version(void *o, zval *return_value)
 	RETVAL_STRING(ver);
 }
 #endif
+#ifdef HAVE_PQPROTOCOLVERSION
 static void php_pqconn_object_read_protocol_version(void *o, zval *return_value)
 {
 	php_pqconn_object_t *obj = o;
 
 	RETVAL_LONG(PQprotocolVersion(obj->intern->conn));
 }
+#endif
+#ifdef HAVE_PQSERVERVERSION
 static void php_pqconn_object_read_server_version(void *o, zval *return_value)
 {
 	php_pqconn_object_t *obj = o;
@@ -524,6 +527,7 @@ static void php_pqconn_object_read_server_version(void *o, zval *return_value)
 	}
 	RETVAL_STRING(ver);
 }
+#endif
 
 static ZEND_RESULT_CODE php_pqconn_update_socket(zval *zobj, php_pqconn_object_t *obj)
 {
@@ -2171,13 +2175,17 @@ PHP_MINIT_FUNCTION(pqconn)
 	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("libraryVersion"), (void *) &ph, sizeof(ph));
 #endif
 
+#ifdef HAVE_PQPROTOCOLVERSION
 	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("protocolVersion"), ZEND_ACC_PUBLIC);
 	ph.read = php_pqconn_object_read_protocol_version;
 	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("protocolVersion"), (void *) &ph, sizeof(ph));
+#endif
 
+#ifdef HAVE_PQSERVERVERSION
 	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("serverVersion"), ZEND_ACC_PUBLIC);
 	ph.read = php_pqconn_object_read_server_version;
 	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("serverVersion"), (void *) &ph, sizeof(ph));
+#endif
 
 	zend_declare_class_constant_long(php_pqconn_class_entry, ZEND_STRL("OK"), CONNECTION_OK);
 	zend_declare_class_constant_long(php_pqconn_class_entry, ZEND_STRL("BAD"), CONNECTION_BAD);

--- a/src/php_pqconn.c
+++ b/src/php_pqconn.c
@@ -2160,19 +2160,19 @@ PHP_MINIT_FUNCTION(pqconn)
 	ph.write = NULL;
 
 #ifdef HAVE_PQLIBVERSION
-	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("libraryVersion"), ZEND_ACC_PUBLIC);
+	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("libraryVersion"), ZEND_ACC_PUBLIC|ZEND_ACC_READONLY);
 	ph.read = php_pqconn_object_read_lib_version;
 	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("libraryVersion"), (void *) &ph, sizeof(ph));
 #endif
 
 #ifdef HAVE_PQPROTOCOLVERSION
-	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("protocolVersion"), ZEND_ACC_PUBLIC);
+	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("protocolVersion"), ZEND_ACC_PUBLIC|ZEND_ACC_READONLY);
 	ph.read = php_pqconn_object_read_protocol_version;
 	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("protocolVersion"), (void *) &ph, sizeof(ph));
 #endif
 
 #ifdef HAVE_PQSERVERVERSION
-	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("serverVersion"), ZEND_ACC_PUBLIC);
+	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("serverVersion"), ZEND_ACC_PUBLIC|ZEND_ACC_READONLY);
 	ph.read = php_pqconn_object_read_server_version;
 	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("serverVersion"), (void *) &ph, sizeof(ph));
 #endif

--- a/src/php_pqconn.c
+++ b/src/php_pqconn.c
@@ -495,13 +495,8 @@ static void php_pqconn_object_write_def_auto_conv(void *o, zval *value)
 static void php_pqconn_object_read_lib_version(void *o, zval *return_value)
 {
 	char ver[16];
-	int v = PQlibVersion();
 
-	if (v < 100000) {
-		slprintf(ver, sizeof(ver), "%d.%d.%d", v/10000, v/100%100, v%100);
-	} else {
-		slprintf(ver, sizeof(ver), "%d.%d", v/10000, v%100);
-	}
+	php_pq_version_to_string(PQlibVersion(), ver, sizeof(ver));
 	RETVAL_STRING(ver);
 }
 #endif
@@ -518,13 +513,8 @@ static void php_pqconn_object_read_server_version(void *o, zval *return_value)
 {
 	php_pqconn_object_t *obj = o;
 	char ver[16];
-	int v = PQserverVersion(obj->intern->conn);
 
-	if (v < 100000) {
-		slprintf(ver, sizeof(ver), "%d.%d.%d", v/10000, v/100%100, v%100);
-	} else {
-		slprintf(ver, sizeof(ver), "%d.%d", v/10000, v%100);
-	}
+	php_pq_version_to_string(PQserverVersion(obj->intern->conn), ver, sizeof(ver));
 	RETVAL_STRING(ver);
 }
 #endif

--- a/src/php_pqconn.c
+++ b/src/php_pqconn.c
@@ -491,6 +491,40 @@ static void php_pqconn_object_write_def_auto_conv(void *o, zval *value)
 	obj->intern->default_auto_convert = zval_get_long(value) & PHP_PQRES_CONV_ALL;
 }
 
+#ifdef HAVE_PQLIBVERSION
+static void php_pqconn_object_read_lib_version(void *o, zval *return_value)
+{
+	char ver[16];
+	int v = PQlibVersion();
+
+	if (v < 100000) {
+		slprintf(ver, sizeof(ver), "%d.%d.%d", v/10000, v/100%100, v%100);
+	} else {
+		slprintf(ver, sizeof(ver), "%d.%d", v/10000, v%100);
+	}
+	RETVAL_STRING(ver);
+}
+#endif
+static void php_pqconn_object_read_protocol_version(void *o, zval *return_value)
+{
+	php_pqconn_object_t *obj = o;
+
+	RETVAL_LONG(PQprotocolVersion(obj->intern->conn));
+}
+static void php_pqconn_object_read_server_version(void *o, zval *return_value)
+{
+	php_pqconn_object_t *obj = o;
+	char ver[16];
+	int v = PQserverVersion(obj->intern->conn);
+
+	if (v < 100000) {
+		slprintf(ver, sizeof(ver), "%d.%d.%d", v/10000, v/100%100, v%100);
+	} else {
+		slprintf(ver, sizeof(ver), "%d.%d", v/10000, v%100);
+	}
+	RETVAL_STRING(ver);
+}
+
 static ZEND_RESULT_CODE php_pqconn_update_socket(zval *zobj, php_pqconn_object_t *obj)
 {
 	zval zsocket, zmember;
@@ -2130,6 +2164,20 @@ PHP_MINIT_FUNCTION(pqconn)
 	ph.write = php_pqconn_object_write_def_auto_conv;
 	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, "defaultAutoConvert", sizeof("defaultAutoConvert")-1, (void *) &ph, sizeof(ph));
 	ph.write = NULL;
+
+#ifdef HAVE_PQLIBVERSION
+	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("libraryVersion"), ZEND_ACC_PUBLIC);
+	ph.read = php_pqconn_object_read_lib_version;
+	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("libraryVersion"), (void *) &ph, sizeof(ph));
+#endif
+
+	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("protocolVersion"), ZEND_ACC_PUBLIC);
+	ph.read = php_pqconn_object_read_protocol_version;
+	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("protocolVersion"), (void *) &ph, sizeof(ph));
+
+	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("serverVersion"), ZEND_ACC_PUBLIC);
+	ph.read = php_pqconn_object_read_server_version;
+	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("serverVersion"), (void *) &ph, sizeof(ph));
 
 	zend_declare_class_constant_long(php_pqconn_class_entry, ZEND_STRL("OK"), CONNECTION_OK);
 	zend_declare_class_constant_long(php_pqconn_class_entry, ZEND_STRL("BAD"), CONNECTION_BAD);

--- a/tests/_skipif.inc
+++ b/tests/_skipif.inc
@@ -6,7 +6,10 @@ _ext("pq");
 include "_setup.inc";
 defined("PQ_DSN") or die("skip PQ_DSN undefined");
 try {
-	new pq\Connection(PQ_DSN);
+	$c = new pq\Connection(PQ_DSN);
+	if (defined("SERVER_MIN") && version_compare(SERVER_MIN, $c->serverVersion) > 0) {
+		die("skip server {$c->serverVersion} is too old, needed " . SERVER_MIN);
+	}
 } catch (pq\Exception $e) {
 	die("skip could not connect to PQ_DSN ".$e->getMessage());
 }

--- a/tests/basic003.phpt
+++ b/tests/basic003.phpt
@@ -1,0 +1,22 @@
+--TEST--
+basic functionality
+--SKIPIF--
+<?php include "_skipif.inc"; ?>
+--FILE--
+<?php
+echo "Test\n";
+include "_setup.inc";
+
+$c = new pq\Connection(PQ_DSN);
+
+var_dump($c->libraryVersion);
+var_dump($c->protocolVersion);
+var_dump($c->serverVersion);
+?>
+DONE
+--EXPECTF--
+Test
+string(%d) "%s"
+int(%d)
+string(%d) "%s"
+DONE

--- a/tests/gh-issue047_jsonb.phpt
+++ b/tests/gh-issue047_jsonb.phpt
@@ -2,6 +2,7 @@
 json conv broken since 2.2.1
 --SKIPIF--
 <?php
+define("SERVER_MIN", "9.4");
 include "_skipif.inc";
 ?>
 --INI--


### PR DESCRIPTION
The problem was about to be able to detect running server version to detect is json is available (the test is failing on RHEL-7 with libpq 9.2)

1st commit add 2 property to the Connection class
* libraryVersion
* protocolVersion
* serverVersion

2nd commit use serverVersion to skip the new json test
