### PR TITLE
make version props typed

### DIFF
--- a/src/php_pq_object.c
+++ b/src/php_pq_object.c
@@ -231,12 +231,13 @@ zval *php_pq_object_read_prop(zend_object *object, zend_string *member, int type
 	if (SUCCESS != php_pq_object_read_prop_ex(object, member, type, tmp)) {
 		return zend_std_read_property(object, member, type, cache_slot, tmp);
 	}
-
+/*
 	zend_std_write_property(object, member, tmp, cache_slot);
 
 	if (cache_slot) {
 		*cache_slot = NULL;
 	}
+*/
 	return tmp;
 }
 #else

--- a/src/php_pqconn.c
+++ b/src/php_pqconn.c
@@ -2160,19 +2160,49 @@ PHP_MINIT_FUNCTION(pqconn)
 	ph.write = NULL;
 
 #ifdef HAVE_PQLIBVERSION
-	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("libraryVersion"), ZEND_ACC_PUBLIC|ZEND_ACC_READONLY);
+#if PHP_VERSION_ID < 80000
+	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("libraryVersion"), ZEND_ACC_PUBLIC);
+#else
+	{
+	zval default_value;
+	zend_string *name = zend_string_init(ZEND_STRL("libraryVersion"), 1);
+	ZVAL_UNDEF(&default_value);
+	zend_declare_typed_property(php_pqconn_class_entry, name, &default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(name);
+	}
+#endif
 	ph.read = php_pqconn_object_read_lib_version;
 	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("libraryVersion"), (void *) &ph, sizeof(ph));
 #endif
 
 #ifdef HAVE_PQPROTOCOLVERSION
-	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("protocolVersion"), ZEND_ACC_PUBLIC|ZEND_ACC_READONLY);
+#if PHP_VERSION_ID < 80000
+	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("protocolVersion"), ZEND_ACC_PUBLIC);
+#else
+	{
+	zval default_value;
+	zend_string *name = zend_string_init(ZEND_STRL("protocolVersion"), 1);
+	ZVAL_UNDEF(&default_value);
+	zend_declare_typed_property(php_pqconn_class_entry, name, &default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(name);
+	}
+#endif
 	ph.read = php_pqconn_object_read_protocol_version;
 	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("protocolVersion"), (void *) &ph, sizeof(ph));
 #endif
 
 #ifdef HAVE_PQSERVERVERSION
-	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("serverVersion"), ZEND_ACC_PUBLIC|ZEND_ACC_READONLY);
+#if PHP_VERSION_ID < 80000
+	zend_declare_property_null(php_pqconn_class_entry, ZEND_STRL("serverVersion"), ZEND_ACC_PUBLIC);
+#else
+	{
+	zval default_value;
+	zend_string *name = zend_string_init(ZEND_STRL("serverVersion"), 1);
+	ZVAL_UNDEF(&default_value);
+	zend_declare_typed_property(php_pqconn_class_entry, name, &default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(name);
+	}
+#endif
 	ph.read = php_pqconn_object_read_server_version;
 	zend_hash_str_add_mem(&php_pqconn_object_prophandlers, ZEND_STRL("serverVersion"), (void *) &ph, sizeof(ph));
 #endif


### PR DESCRIPTION
This also make them really readonly

```
        Property [ public readonly string $libraryVersion ]
        Property [ public readonly int $protocolVersion ]
        Property [ public readonly string $serverVersion ]
```

BUT it breaks because of call to "write" in the "read" function, which is commented out here
Can you please explain why this (don't see anything similar in php-src) ?