### PR TITLE
Fix incompatible pointer types (32-bit)

### DIFF
--- a/src/php_pqlob.c
+++ b/src/php_pqlob.c
@@ -169,7 +169,7 @@ static int php_pqlob_stream_flush(php_stream *stream)
 	return SUCCESS;
 }
 
-static ZEND_RESULT_CODE php_pqlob_stream_seek(php_stream *stream, off_t offset, int whence, off_t *newoffset)
+static ZEND_RESULT_CODE php_pqlob_stream_seek(php_stream *stream, zend_off_t offset, int whence, zend_off_t *newoffset)
 {
 	ZEND_RESULT_CODE rv = FAILURE;
 	php_pqlob_object_t *obj = stream->abstract;

--- a/src/php_pqres.c
+++ b/src/php_pqres.c
@@ -398,24 +398,24 @@ static zend_object_iterator_funcs php_pqres_iterator_funcs = {
 #endif
 };
 
-static inline ZEND_RESULT_CODE php_pqres_count_elements_ex(zend_object *object, long *count)
+static inline ZEND_RESULT_CODE php_pqres_count_elements_ex(zend_object *object, zend_long *count)
 {
 	php_pqres_object_t *obj = PHP_PQ_OBJ(NULL, object);
 
 	if (!obj->intern) {
 		return FAILURE;
 	} else {
-		*count = (long) PQntuples(obj->intern->res);
+		*count = (zend_long) PQntuples(obj->intern->res);
 		return SUCCESS;
 	}
 }
 #if PHP_VERSION_ID >= 80000
-static ZEND_RESULT_CODE php_pqres_count_elements(zend_object *object, long *count)
+static ZEND_RESULT_CODE php_pqres_count_elements(zend_object *object, zend_long *count)
 {
 	return php_pqres_count_elements_ex(object, count);
 }
 #else
-static ZEND_RESULT_CODE php_pqres_count_elements(zval *object, long *count)
+static ZEND_RESULT_CODE php_pqres_count_elements(zval *object, zend_long *count)
 {
 	return php_pqres_count_elements_ex(Z_OBJ_P(object), count);
 }

--- a/src/php_pqres.c
+++ b/src/php_pqres.c
@@ -736,7 +736,7 @@ static ZEND_RESULT_CODE column_nn(php_pqres_object_t *obj, zval *zcol, php_pqres
 	}
 
 	if (!col->name) {
-		php_error_docref(NULL, E_WARNING, "Failed to find column at index %ld", index);
+		php_error_docref(NULL, E_WARNING, "Failed to find column at index " ZEND_LONG_FMT, index);
 		return FAILURE;
 	}
 	if (col->num == -1) {
@@ -791,7 +791,7 @@ static int apply_bound(zval *zbound, int argc, va_list argv, zend_hash_key *key)
 	ZEND_RESULT_CODE *rv = va_arg(argv, ZEND_RESULT_CODE *);
 
 	if (!(zvalue = zend_hash_index_find(Z_ARRVAL_P(zrow), key->h))) {
-		php_error_docref(NULL, E_WARNING, "Failed to find column ad index %lu", key->h);
+		php_error_docref(NULL, E_WARNING, "Failed to find column ad index " ZEND_ULONG_FMT, key->h);
 		*rv = FAILURE;
 		return ZEND_HASH_APPLY_STOP;
 	} else {

--- a/src/php_pqres.c
+++ b/src/php_pqres.c
@@ -1172,7 +1172,7 @@ static PHP_METHOD(pqres, count) {
 	zend_restore_error_handling(&zeh);
 
 	if (SUCCESS == rv) {
-		long count;
+		zend_long count;
 
 		if (SUCCESS != php_pqres_count_elements_ex(Z_OBJ_P(getThis()), &count)) {
 			throw_exce(EX_UNINITIALIZED, "pq\\Result not initialized");


### PR DESCRIPTION
With GCC 14 (Fedora 40) [-Wincompatible-pointer-types] becomes a error (and is indeed one)

See https://kojipkgs.fedoraproject.org//work/tasks/285/112370285/build.log

```
/builddir/build/BUILD/php-pecl-pq-2.2.2/pq-2.2.2/src/php_pqlob.c:204:9: error: initialization of 'int (*)(php_stream *, zend_off_t,  int,  zend_off_t *)' {aka 'int (*)(struct _php_stream *, int,  int,  int *)'} from incompatible pointer type 'ZEND_RESULT_CODE (*)(php_stream *, off_t,  int,  off_t *)' {aka 'ZEND_RESULT_CODE (*)(struct _php_stream *, long int,  int,  long int *)'} [-Wincompatible-pointer-types]
  204 |         php_pqlob_stream_seek,
      |         ^~~~~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/php-pecl-pq-2.2.2/pq-2.2.2/src/php_pqlob.c:204:9: note: (near initialization for 'php_pqlob_stream_ops.seek')
/builddir/build/BUILD/php-pecl-pq-2.2.2/pq-2.2.2/src/php_pqlob.c: In function 'php_pqlob_object_update_stream':
/builddir/build/BUILD/php-pecl-pq-2.2.2/pq-2.2.2/src/php_pqlob.c:212:14: warning: unused variable 'zobj' [-Wunused-variable]
  212 |         zval zobj, zmember;
      |              ^~~~
/builddir/build/BUILD/php-pecl-pq-2.2.2/pq-2.2.2/src/php_pqres.c: In function 'column_nn':
/builddir/build/BUILD/php-pecl-pq-2.2.2/pq-2.2.2/src/php_pqres.c:739:85: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'zend_long' {aka 'int'} [-Wformat=]
  739 |                 php_error_docref(NULL, E_WARNING, "Failed to find column at index %ld", index);
      |                                                                                   ~~^   ~~~~~
      |                                                                                     |   |
      |                                                                                     |   zend_long {aka int}
      |                                                                                     long int
      |                                                                                   %d
/builddir/build/BUILD/php-pecl-pq-2.2.2/pq-2.2.2/src/php_pqres.c: In function 'apply_bound':
/builddir/build/BUILD/php-pecl-pq-2.2.2/pq-2.2.2/src/php_pqres.c:794:85: warning: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'zend_ulong' {aka 'unsigned int'} [-Wformat=]
  794 |                 php_error_docref(NULL, E_WARNING, "Failed to find column ad index %lu", key->h);
      |                                                                                   ~~^   ~~~~~~
      |                                                                                     |      |
      |                                                                                     |      zend_ulong {aka unsigned int}
      |                                                                                     long unsigned int
      |                                                                                   %u
make: *** [Makefile:240: src/php_pqlob.lo] Error 1
make: *** Waiting for unfinished jobs....
/builddir/build/BUILD/php-pecl-pq-2.2.2/pq-2.2.2/src/php_pqres.c: In function 'zm_startup_pqres':
/builddir/build/BUILD/php-pecl-pq-2.2.2/pq-2.2.2/src/php_pqres.c:1282:50: error: assignment to 'zend_object_count_elements_t' {aka 'ZEND_RESULT_CODE (*)(struct _zend_object *, int *)'} from incompatible pointer type 'ZEND_RESULT_CODE (*)(zend_object *, long int *)' {aka 'ZEND_RESULT_CODE (*)(struct _zend_object *, long int *)'} [-Wincompatible-pointer-types]
 1282 |         php_pqres_object_handlers.count_elements = php_pqres_count_elements;
      |                                                  ^
```