### PR TITLE
Relax text expectation (for 8.5)

### DIFF
--- a/tests/lob003.phpt
+++ b/tests/lob003.phpt
@@ -25,7 +25,7 @@ Test
 resource(%d) of type (stream)
 resource(%d) of type (stream)
 
-Warning: fclose(): %d is not a valid stream resource in %s on line %d
+Warning: fclose(): %s in %s on line %d
 resource(%d) of type (stream)
 string(0) ""
 DONE


### PR DESCRIPTION
Using 8.5.0alpha1

```
TEST 37/54 [tests/lob003.phpt]
========DIFF========
--
     resource(%d) of type (stream)
     resource(%d) of type (stream)
     
005- Warning: fclose(): %d is not a valid stream resource in %s on line %d
005+ Warning: fclose(): cannot close the provided stream, as it must not be manually closed in /dev/shm/BUILD/php85-php-pecl-pq-2.2.3-build/php85-php-pecl-pq-2.2.3/pq-2.2.3/tests/lob003.php on line 12
     resource(%d) of type (stream)
     string(0) ""
     DONE
========DONE========
FAIL large object closing stream [tests/lob003.phpt] 

```